### PR TITLE
Add minimal invoice upload module

### DIFF
--- a/addons/invoice_upload/__init__.py
+++ b/addons/invoice_upload/__init__.py
@@ -1,0 +1,3 @@
+# __init__.py
+# Load the module's models package when Odoo starts.
+from . import models

--- a/addons/invoice_upload/__manifest__.py
+++ b/addons/invoice_upload/__manifest__.py
@@ -1,0 +1,17 @@
+# __manifest__.py
+# Module metadata and minimal dependencies for our invoice upload module.
+{
+    'name': 'Invoice Upload',
+    'version': '16.0.1.0.0',
+    'category': 'Accounting',
+    'summary': 'Simple upload of incoming and outgoing invoices with auto posting',
+    'description': 'Upload invoices as attachments and generate minimal journal entries.',
+    'depends': ['base', 'account', 'account_edi', 'account_edi_ubl_cii'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/invoice_views.xml',
+    ],
+    'installable': True,
+    'application': False,
+    'license': 'LGPL-3',
+}

--- a/addons/invoice_upload/models/__init__.py
+++ b/addons/invoice_upload/models/__init__.py
@@ -1,0 +1,3 @@
+# models/__init__.py
+# Import the invoice entry model so Odoo loads it.
+from . import invoice_entry

--- a/addons/invoice_upload/models/invoice_entry.py
+++ b/addons/invoice_upload/models/invoice_entry.py
@@ -1,0 +1,94 @@
+# models/invoice_entry.py
+# Main model to store uploaded invoices and generate accounting entries.
+
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
+from lxml import etree
+import base64
+
+class InvoiceEntry(models.Model):
+    """Model used to upload invoice documents and create minimal journal entries."""
+
+    _name = 'invoice.entry'
+    _description = 'Uploaded Invoice'
+
+    # Basic information
+    name = fields.Char(string='Description', default='New Invoice')
+    file = fields.Binary(string='Invoice File', attachment=True, required=True,
+                         help='Upload the XML or PDF invoice file.')
+    file_name = fields.Char(string='File Name')
+
+    # Computed invoice type based on the uploaded XML data
+    invoice_type = fields.Selection([
+        ('in_invoice', 'Vendor Bill'),
+        ('in_refund', 'Vendor Credit'),
+        ('out_invoice', 'Customer Invoice'),
+        ('out_refund', 'Customer Credit'),
+    ], string='Invoice Type', compute='_compute_invoice_type', store=True)
+
+    # Link to the generated account.move
+    move_id = fields.Many2one('account.move', string='Journal Entry', readonly=True)
+
+    state = fields.Selection([
+        ('draft', 'Draft'),
+        ('processed', 'Processed')
+    ], default='draft', string='Status')
+
+    @api.depends('file')
+    def _compute_invoice_type(self):
+        """Detect the invoice type from the uploaded XML file."""
+        for entry in self:
+            entry.invoice_type = False
+            if not entry.file:
+                continue
+            try:
+                xml_root = etree.fromstring(base64.b64decode(entry.file))
+            except Exception:
+                # Cannot parse XML -> default to vendor bill
+                entry.invoice_type = 'in_invoice'
+                continue
+            # Determine if this is an invoice or credit note
+            inv_type = 'invoice'
+            if xml_root.tag.endswith('CreditNote'):
+                inv_type = 'refund'
+            # Compare the VAT numbers to know if we are supplier or customer
+            vat = (entry.env.company.vat or '').replace(' ', '').upper()
+            supplier_vat = xml_root.findtext('.//{*}AccountingSupplierParty//{*}CompanyID')
+            customer_vat = xml_root.findtext('.//{*}AccountingCustomerParty//{*}CompanyID')
+            supplier_vat = (supplier_vat or '').replace(' ', '').upper()
+            customer_vat = (customer_vat or '').replace(' ', '').upper()
+            if vat and vat == supplier_vat:
+                entry.invoice_type = f'out_{inv_type}'
+            elif vat and vat == customer_vat:
+                entry.invoice_type = f'in_{inv_type}'
+            else:
+                # Fallback to vendor bill
+                entry.invoice_type = f'in_{inv_type}'
+
+    def action_process(self):
+        """Create a journal entry from the uploaded file."""
+        for entry in self:
+            if not entry.file:
+                raise UserError(_('Please upload an invoice file.'))
+            # Create an attachment linked to this entry
+            attachment = entry.env['ir.attachment'].create({
+                'name': entry.file_name or 'invoice',
+                'datas': entry.file,
+                'res_model': 'invoice.entry',
+                'res_id': entry.id,
+            })
+            entry.state = 'processed'
+            # Choose journal according to invoice type
+            move_type = entry.invoice_type or 'in_invoice'
+            journal_type = 'sale' if move_type.startswith('out_') else 'purchase'
+            journal = entry.env['account.journal'].search([
+                ('type', '=', journal_type),
+            ], limit=1)
+            if not journal:
+                raise UserError(_('No journal found for type %s') % journal_type)
+            # Create the account.move using Odoo's helper
+            move = journal.with_context(default_move_type=move_type)._create_document_from_attachment(attachment.id)
+            entry.move_id = move.id
+            # Attach the uploaded file to the created move as well
+            attachment.write({'res_model': 'account.move', 'res_id': move.id})
+        return True

--- a/addons/invoice_upload/security/ir.model.access.csv
+++ b/addons/invoice_upload/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+# security/ir.model.access.csv
+# Grants basic access to the invoice.entry model for all internal users.
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_invoice_entry_user,invoice_entry_user,model_invoice_entry,base.group_user,1,1,1,1

--- a/addons/invoice_upload/views/invoice_views.xml
+++ b/addons/invoice_upload/views/invoice_views.xml
@@ -1,0 +1,48 @@
+<!-- views/invoice_views.xml
+     XML definitions for the invoice entry list and form views.
+-->
+<odoo>
+    <record id="view_invoice_entry_tree" model="ir.ui.view">
+        <field name="name">invoice.entry.tree</field>
+        <field name="model">invoice.entry</field>
+        <field name="arch" type="xml">
+            <tree string="Uploaded Invoices">
+                <field name="name"/>
+                <field name="invoice_type"/>
+                <field name="move_id"/>
+                <field name="state"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_invoice_entry_form" model="ir.ui.view">
+        <field name="name">invoice.entry.form</field>
+        <field name="model">invoice.entry</field>
+        <field name="arch" type="xml">
+            <form string="Invoice Entry">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="file" filename="file_name"/>
+                        <field name="file_name"/>
+                        <field name="invoice_type" readonly="1"/>
+                        <field name="move_id" readonly="1"/>
+                        <field name="state" readonly="1"/>
+                    </group>
+                    <footer>
+                        <button string="Process" type="object" name="action_process" states="draft" class="oe_highlight"/>
+                        <button string="Close" class="btn-secondary" special="cancel"/>
+                    </footer>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_invoice_entry" model="ir.actions.act_window">
+        <field name="name">Invoice Entries</field>
+        <field name="res_model">invoice.entry</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem id="menu_invoice_entry" name="Invoice Upload" parent="account.menu_finance" action="action_invoice_entry"/>
+</odoo>


### PR DESCRIPTION
## Summary
- add `invoice_upload` module for minimal invoice processing
- provide model `invoice.entry` to upload invoices and auto-detect type
- create menu and views for document upload and processing
- grant base users access to invoice entries

## Testing
- `python3 -m py_compile addons/invoice_upload/__init__.py addons/invoice_upload/models/__init__.py addons/invoice_upload/models/invoice_entry.py`

------
https://chatgpt.com/codex/tasks/task_e_6878e3a5ce6883268a7a9d22f150993c